### PR TITLE
run volume does not mount, /var/run is a symlink to /run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN chmod 755 /start
 EXPOSE 5432
 
 VOLUME ["/var/lib/postgresql"]
-VOLUME ["/var/run/postgresql"]
+VOLUME ["/run/postgresql"]
 
 CMD ["/start"]


### PR DESCRIPTION
this is not working as is, Centos 6.5, `Docker version 1.1.2, build d84a070/1.1.2`. The ubuntu base image presents `/var/run` as a symlink to `/run`. As is, the image fails to start, throwing 

```
lxc-start: No such file or directory - failed to mount '/var/lib/docker/vfs/dir/6084a62db34f3a46ba35d18f57c57969111da52190571cf845920d6942b1734c' on '/usr/lib64/lxc/rootfs///var/run/postgresql'
lxc-start: failed to setup the mount entries for '737db784744785845206b6509d3ffa0e1f20770503e5a7b7b107f3fdd9efdcd8'
```

Modifying the volume to `/run` seems to resolve the problem. 
