### PR TITLE
added trust on samenet in pg_hba

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,23 @@ docker run --name postgresql -d \
 
 , will create a user *dbuser* with the password *dbpass*. It will also create a database named *dbname* and the *dbuser* user will have full access to the *dbname* database.
 
+The PSQL_TRUST_LOCALNET environment variable can be used to configure postgres to trust connections on the same network.  This
+is handy for other containers to connect without authentication. To enable this behavior, set PSQL_TRUST_LOCALNET to Y.
+
+For example,
+
+```bash
+docker run --name postgresql -d \
+  -e 'PSQL_TRUST_LOCALNET=Y' \
+  sameersbn/postgresql:9.4
+```
+
+This has the effect of adding the following to the pg_hba.conf file:
+
+```
+host    all             all             samenet                 trust
+```
+
 # Configuration
 
 ## Data Store

--- a/start
+++ b/start
@@ -6,6 +6,11 @@ PG_CONFDIR="/etc/postgresql/${PG_VERSION}/main"
 PG_BINDIR="/usr/lib/postgresql/${PG_VERSION}/bin"
 PG_DATADIR="${PG_HOME}/${PG_VERSION}/main"
 
+# set this env variable to Y to enable a line in the
+# pg_hba.conf file to trust samenet.  this can be used to connect
+# from other containers on the same host without authentication
+PSQL_TRUST_LOCALNET="N"
+
 DB_NAME=${DB_NAME:-}
 DB_USER=${DB_USER:-}
 DB_PASS=${DB_PASS:-}
@@ -27,9 +32,14 @@ cat >> ${PG_CONFDIR}/postgresql.conf <<EOF
 listen_addresses = '*'
 EOF
 
+trust_local="host    all             all             samenet                 trust"
+if [ ${PSQL_TRUST_LOCALNET} = "Y" ]; then
+  echo "Enabling trust samenet in pg_hba.conf..."
+  echo ${trust_local} >> ${PG_CONFDIR}/pg_hba.conf
+fi
+
 # allow remote connections to postgresql database
 cat >> ${PG_CONFDIR}/pg_hba.conf <<EOF
-host    all             all             samenet                 trust
 host    all             all             0.0.0.0/0               md5
 EOF
 

--- a/start
+++ b/start
@@ -9,7 +9,7 @@ PG_DATADIR="${PG_HOME}/${PG_VERSION}/main"
 # set this env variable to Y to enable a line in the
 # pg_hba.conf file to trust samenet.  this can be used to connect
 # from other containers on the same host without authentication
-PSQL_TRUST_LOCALNET="N"
+PSQL_TRUST_LOCALNET=${PSQL_TRUST_LOCALNET:N}
 
 DB_NAME=${DB_NAME:-}
 DB_USER=${DB_USER:-}

--- a/start
+++ b/start
@@ -29,6 +29,7 @@ EOF
 
 # allow remote connections to postgresql database
 cat >> ${PG_CONFDIR}/pg_hba.conf <<EOF
+host    all             all             samenet                 trust
 host    all             all             0.0.0.0/0               md5
 EOF
 


### PR DESCRIPTION
I don't know if this makes sense for a default distribution environment.  For me it's handy to have the samenet trusted.  that way the other links to this container simply can run psql -h db dbname (or whatever the alias is). If this sort of security is frowned upon, I can take another crack at this with an environment variable to trigger the insertion of it, like DB_SAMENET_TRUSTED==true?