### PR TITLE
changed postgres user and group to id #600.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM sameersbn/ubuntu:14.04.20150120
 MAINTAINER sameer@damagehead.com
 
 ENV PG_VERSION 9.4
+
+RUN groupadd -g 600 postgres &&\
+    useradd postgres -m -g 600 -s /bin/bash -u 600
+
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
  && echo 'deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
  && apt-get update \

--- a/start
+++ b/start
@@ -32,17 +32,17 @@ cat >> ${PG_CONFDIR}/postgresql.conf <<EOF
 listen_addresses = '*'
 EOF
 
-# allow remote connections to postgresql database
-cat >> ${PG_CONFDIR}/pg_hba.conf <<EOF
-host    all             all             0.0.0.0/0               md5
-EOF
-
 if [ ${PSQL_TRUST_LOCALNET} = "true" ]; then
   echo "Enabling trust samenet in pg_hba.conf..."
   cat >> ${PG_CONFDIR}/pg_hba.conf <<EOF
 host    all             all             samenet                 trust
 EOF
 fi
+
+# allow remote connections to postgresql database
+cat >> ${PG_CONFDIR}/pg_hba.conf <<EOF
+host    all             all             0.0.0.0/0               md5
+EOF
 
 cd ${PG_HOME}
 


### PR DESCRIPTION
when I run the docker-postgresql image on my host on a mounted volume, I see this:

```
sudo rm -rf /tmp/pgdir
mkdir /tmp/pgdir
docker run --name postgresql -d  \
    -v /tmp/pgdir:/var/lib/postgresql  \
    -e 'DB_USER=dbuser' -e 'DB_PASS=dbpass' -e 'DB_NAME=dbname'  sameersbn/postgresql:9.4
```

And here is the output of an ls -l:

```
ls -altr /tmp
drwxr-xr-x  3 messagebus fuse 4096 Feb  9 16:42 pgdir
```

that is simply because my host has a userid 102 mapped to messagebus, and groupid 106 mapped to fuse.  What would you think about mapping the user/group to probably unused ids?  In my Dockerfile I used 600 for each, so:

```
sudo rm -rf /tmp/pgdir
mkdir /tmp/pgdir
docker run --name postgresql -d  \
    -v /tmp/pgdir:/var/lib/postgresql  \
    -e 'DB_USER=dbuser' -e 'DB_PASS=dbpass' -e 'DB_NAME=dbname'  tacodata/docker-postgresql
```

and the ls -l output:

```
ls -altr /tmp
drwxr-xr-x  3  600  600 4096 Feb  9 17:15 pgdir
```

-g