### PR TITLE
start: maybe change DSM config in postgresql.conf

### DIFF
--- a/start
+++ b/start
@@ -51,6 +51,12 @@ if [[ ${PSQL_SSLMODE} == disable ]]; then
   sed 's/ssl = true/#ssl = true/' -i ${PG_CONFDIR}/postgresql.conf
 fi
 
+# Change DSM from `posix' to `sysv' if we are inside an lx-brand container
+if [[ $(uname -v) == "BrandZ virtual linux" ]]; then
+  sed 's/\(dynamic_shared_memory_type = \)posix/\1sysv/' \
+    -i ${PG_CONFDIR}/postgresql.conf
+fi
+
 # listen on all interfaces
 cat >> ${PG_CONFDIR}/postgresql.conf <<EOF
 listen_addresses = '*'


### PR DESCRIPTION
I attempted to deploy docker-postgresql into Joyent's Triton service and ran into the following error:
```
FATAL: could not open shared memory segment "/PostgreSQL.1804289383": Permission denied
```
I tracked this to the fact that `dynamic_shared_memory_type` is set to `posix` by default.  I don't know how pervasive this problem is, but my patch is specific to lx-branded zones on SmartOS.

Once this change was made, I was able to deploy the container and start the database.