### PR TITLE
Now setting ACLs for resolv.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV PG_BINDIR=/usr/lib/postgresql/${PG_VERSION}/bin \
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
  && echo 'deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
  && apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-${PG_VERSION} postgresql-client-${PG_VERSION} postgresql-contrib-${PG_VERSION} \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-${PG_VERSION} postgresql-client-${PG_VERSION} postgresql-contrib-${PG_VERSION} acl \
  && ln -sf ${PG_DATADIR}/postgresql.conf /etc/postgresql/${PG_VERSION}/main/postgresql.conf \
  && ln -sf ${PG_DATADIR}/pg_hba.conf /etc/postgresql/${PG_VERSION}/main/pg_hba.conf \
  && ln -sf ${PG_DATADIR}/pg_ident.conf /etc/postgresql/${PG_VERSION}/main/pg_ident.conf \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,8 @@ if [[ -z ${1} ]]; then
   create_database
   create_replication_user
 
+  set_resolvconf_perms
+
   echo "Starting PostgreSQL ${PG_VERSION}..."
   exec start-stop-daemon --start --chuid ${PG_USER}:${PG_USER} \
     --exec ${PG_BINDIR}/postgres -- -D ${PG_DATADIR} ${EXTRA_ARGS}

--- a/runtime/functions
+++ b/runtime/functions
@@ -342,3 +342,8 @@ create_replication_user() {
     esac
   fi
 }
+
+set_resolvconf_perms() {
+  echo "Setting resolv ACLs..."
+  setfacl -m user:${PG_USER}:r /etc/resolv.conf
+}


### PR DESCRIPTION
Noticed Postgres can't resolve `localhost` on my server - and this disables autovacuum. This happened because of weird ACLs on `/etc/resolv.conf`, which prevented user `postgres` from reading it.

This PR enforces `r--` mode for user `postgres`, fixing the bug - shouldn't affect anyone not experiencing it.