### PR TITLE
Actually enable logging

### DIFF
--- a/runtime/functions
+++ b/runtime/functions
@@ -246,6 +246,7 @@ initialize_database() {
   # configure logging
   set_postgresql_param "log_directory" "${PG_LOGDIR}"
   set_postgresql_param "log_filename" "postgresql-${PG_VERSION}-main.log"
+  set_postgresql_param "logging_collector" "on"
 
   # trust connections from local network
   if [[ ${PG_TRUST_LOCALNET} == true ]]; then


### PR DESCRIPTION
The `log_directory` and `log_filename` directives require `logging_collector` to be set to `on` to be effective.
