### PR TITLE
Fix permission error on Synology NAS

### DIFF
--- a/runtime/functions
+++ b/runtime/functions
@@ -32,6 +32,7 @@ create_datadir() {
     find ${PG_DATADIR} -type d -exec chmod 0700 {} \;
   fi
   chown -R ${PG_USER}:${PG_USER} ${PG_HOME}
+  chmod 700 ${PG_HOME}
 }
 
 create_certdir() {
@@ -70,7 +71,7 @@ set_postgresql_param() {
         echo "‣ Setting postgresql.conf parameter: ${key} = '${value}'"
       fi
       value="$(echo "${value}" | sed 's|[&]|\\&|g')"
-      exec_as_postgres sed -i "s|^[#]*[ ]*${key} = .*|${key} = '${value}'|" ${PG_CONF}
+      sed -i "s|^[#]*[ ]*${key} = .*|${key} = '${value}'|" ${PG_CONF}
     fi
   fi
 }
@@ -86,7 +87,7 @@ set_recovery_param() {
         true)  echo "‣ Setting primary_conninfo parameter: ${key}" ;;
         *) echo "‣ Setting primary_conninfo parameter: ${key} = '${value}'" ;;
       esac
-      exec_as_postgres sed -i "s|${key}=[^ ']*|${key}=${value}|" ${PG_RECOVERY_CONF}
+      sed -i "s|${key}=[^ ']*|${key}=${value}|" ${PG_RECOVERY_CONF}
     fi
   fi
 }


### PR DESCRIPTION
There were two bugs when trying to run the image on Synology NAS (DSM 6.2.1-23824 Update 4):
1) `initdb` failed because the permission of ${PG_HOME} was 000, and
2) `sed -i` failed because `sed` internally could not generate temporary
files

It now works fine on Synology NAS and Ubuntu 16.04 (with [sameersbn/docker-gitlab](https://github.com/sameersbn/docker-gitlab)).