### PR TITLE
Add windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Start PostgreSQL using:
 ```bash
 docker run --name postgresql -itd --restart always \
   --publish 5432:5432 \
-  --volume /srv/docker/postgresql:/var/lib/postgresql \
+  --volume postgresql:/var/lib/postgresql \
   sameersbn/postgresql:10-2
 ```
 
@@ -91,7 +91,7 @@ docker exec -it postgresql sudo -u postgres psql
 
 ## Persistence
 
-For PostgreSQL to preserve its state across container shutdown and startup you should mount a volume at `/var/lib/postgresql`.
+For PostgreSQL to preserve its state across container shutdown and startup you should mount a volume at `/var/lib/postgresql`. If you don't like the default volume destination then you can change it
 
 > *The [Quickstart](#quickstart) command already mounts a volume for persistence.*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,4 @@ PostgreSQL:
     - REPLICATION_PASS=
     - REPLICATION_SSLMODE=
   volumes:
-    - /srv/docker/postgresql:/var/lib/postgresql
+    - postgresql:/var/lib/postgresql


### PR DESCRIPTION
Currently `docker-compose.yml` and README assumes user has linux, but it's not always the case.

I replaced absolute linux paths with docker system volumes that allows to run in both windows and linux in the same manner. Checked it works as expected on my own Windows machine (tbh it's actually the reason I even changed it).