### PR TITLE
functions: Fixing a logical mistake

### DIFF
--- a/runtime/functions
+++ b/runtime/functions
@@ -28,9 +28,11 @@ map_uidgid() {
 create_datadir() {
   echo "Initializing datadir..."
   mkdir -p ${PG_HOME}
+  if [[ -f ${PG_DATADIR} ]]; then
+    chmod 0700 ${PG_DATADIR}
+  fi
   if [[ -d ${PG_DATADIR} ]]; then
-    chmod 0600 $( find ${PG_DATADIR} -type f )
-    chmod 0700 $( find ${PG_DATADIR} -type d )
+    chmod 0700 ${PG_DATADIR}
   fi
   chown -R ${PG_USER}:${PG_USER} ${PG_HOME}
 }


### PR DESCRIPTION
I'm not getting how this section of code could ever be made.
1. Why do we search for a file or directory, when we have an if-clause on top, which already checks for it? Searching for something that has already been found is pointless.
2. Why is there a search for a file (that is the bug I'm actually running into here), if we already know the path is a file type of data? It's like checking for something and knowing already it will fail.

When thinking of the name of the environment variable, I think only the directory check is necessary, but someone added the "-f" check. Maybe to test for symlinks? (It would be normally done via "-L" if I'm not wrong, but "-f" catches them, too.) For the reason of knowing to less of the history of this section, I'm keeping as much logic as possible.