### PR TITLE
fix PG_DATADIR initialization for cases when empty or contains too many files

### DIFF
--- a/runtime/functions
+++ b/runtime/functions
@@ -29,8 +29,8 @@ create_datadir() {
   echo "Initializing datadir..."
   mkdir -p ${PG_HOME}
   if [[ -d ${PG_DATADIR} ]]; then
-    chmod 0600 $( find ${PG_DATADIR} -type f )
-    chmod 0700 $( find ${PG_DATADIR} -type d )
+    find ${PG_DATADIR} -type f | xargs chmod 0600
+    find ${PG_DATADIR} -type d | xargs chmod 0700
   fi
   chown -R ${PG_USER}:${PG_USER} ${PG_HOME}
 }


### PR DESCRIPTION
Previous implementation passed nothing to `chmod` when `PG_DATADIR` is empty. This results in `chmod` raises syntax error and wrong permissions will not be corrected : This is the cause of problem reported in [sameersbn/docker-gitlab#2224](https://github.com/sameersbn/docker-gitlab/issues/2224#issuecomment-686777669)  
We also can see `Argument list too long` error when `PG_DATADIR` contains too many files / directories (restriction defined by ARG_MAX) : this is reported in #148

This PR make `create_datadir()` to handle those situations by using `xargs`.
