### PR TITLE
Replace deprecated `apt-key` by `wget | gpg`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:jammy-20230605 AS add-apt-repositories
 
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg \
- && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
- && echo 'deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main' >> /etc/apt/sources.list
+ && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg \
+ && echo 'deb [signed-by=/etc/apt/trusted.gpg.d/apt.postgresql.org.gpg] http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main' >> /etc/apt/sources.list
 
 FROM ubuntu:jammy-20230605
 
@@ -20,7 +20,7 @@ ENV PG_APP_HOME="/etc/docker-postgresql" \
 ENV PG_BINDIR=/usr/lib/postgresql/${PG_VERSION}/bin \
     PG_DATADIR=${PG_HOME}/${PG_VERSION}/main
 
-COPY --from=add-apt-repositories /etc/apt/trusted.gpg /etc/apt/trusted.gpg
+COPY --from=add-apt-repositories /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg
 
 COPY --from=add-apt-repositories /etc/apt/sources.list /etc/apt/sources.list
 


### PR DESCRIPTION
`apt-key` is deprecated and reports warning on build.  
This PR replace it by `wget ${key_file_url} | gpg --dearmor -o ${destination_path}`.  

Reference: similar work on sameersbn/docker-gitlab@3cac65dd8849e44b1285b921329e75efa10018c0 (as a part of sameersbn/docker-gitlab#3059)

note: This PR is ported from my fork kkimurak/docker-postgresql@483fccf19212d4f60a3d646eb9eeb614cc974cb7, included in releases 20250703 and later and is available for testing.