### PR TITLE
Replace `awk -F` based csv iteration by IFS + built-in for loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ docker run --name postgresql -itd \
 
 The above command enables the `unaccent` and `pg_trgm` modules on the databases listed in `DB_NAME`, namely `db1` and `db2`.
 
+Each comma separated field can contain whitespace, allowing you to set arbitrary options (such as `CASCADE` ). For full syntax, refer official documentation about [CREATE EXTENSION](https://www.postgresql.org/docs/current/sql-createextension.html).
+
 > **NOTE**:
 >
 > This option deprecates the `DB_UNACCENT` parameter.

--- a/runtime/functions
+++ b/runtime/functions
@@ -318,7 +318,7 @@ load_extensions() {
     psql -U ${PG_USER} -d ${database} -c "CREATE EXTENSION IF NOT EXISTS unaccent;" >/dev/null 2>&1
   fi
 
-  IFS_ORG=$IFS
+  local IFS_ORG=$IFS
   IFS=,
   for extension in ${DB_EXTENSION}; do
     echo "‣ Loading ${extension} extension..."
@@ -334,7 +334,7 @@ create_database() {
         echo "INFO! Database cannot be created on a $REPLICATION_MODE node. Skipping..."
         ;;
       *)
-        IFS_ORG=$IFS
+        local IFS_ORG=$IFS
         IFS=,
         for database in ${DB_NAME}; do
           echo "Creating database: ${database}..."

--- a/runtime/functions
+++ b/runtime/functions
@@ -318,10 +318,13 @@ load_extensions() {
     psql -U ${PG_USER} -d ${database} -c "CREATE EXTENSION IF NOT EXISTS unaccent;" >/dev/null 2>&1
   fi
 
-  for extension in $(awk -F',' '{for (i = 1 ; i <= NF ; i++) print $i}' <<< "${DB_EXTENSION}"); do
+  IFS_ORG=$IFS
+  IFS=,
+  for extension in ${DB_EXTENSION}; do
     echo "‣ Loading ${extension} extension..."
     psql -U ${PG_USER} -d ${database} -c "CREATE EXTENSION IF NOT EXISTS ${extension};" >/dev/null 2>&1
   done
+  IFS=$IFS_ORG
 }
 
 create_database() {
@@ -331,7 +334,9 @@ create_database() {
         echo "INFO! Database cannot be created on a $REPLICATION_MODE node. Skipping..."
         ;;
       *)
-        for database in $(awk -F',' '{for (i = 1 ; i <= NF ; i++) print $i}' <<< "${DB_NAME}"); do
+        IFS_ORG=$IFS
+        IFS=,
+        for database in ${DB_NAME}; do
           echo "Creating database: ${database}..."
           if [[ -z $(psql -U ${PG_USER} -Atc "SELECT 1 FROM pg_catalog.pg_database WHERE datname = '${database}'";) ]]; then
             psql -U ${PG_USER} -c "CREATE DATABASE \"${database}\" WITH TEMPLATE = \"${DB_TEMPLATE}\";" >/dev/null
@@ -344,6 +349,7 @@ create_database() {
             psql -U ${PG_USER} -c "GRANT ALL PRIVILEGES ON DATABASE \"${database}\" to \"${DB_USER}\";" >/dev/null
           fi
         done
+        IFS=$IFS_ORG
         ;;
     esac
   fi


### PR DESCRIPTION
`awk -F,` splits values by comma but built-in for loop reinterpret each values. This behavior does not allow us to contain internal field separator (such as whitespace) in DB_EXTENSION for example.

By setting environment variable `IFS` we can control internal field separator that will affect to for-in loop. This PR replace `awk -F,` based word splitting by setting `IFS` then for-in loop.  
This change allow us to include additional options to each element in `DB_EXTENSIONS` - for example `--env 'DB_EXTENSION=extension_name CASCADE` (`CASCADE` is an option to load extensions required by specified extension).  
See full syntax in https://www.postgresql.org/docs/current/sql-createextension.html .

note: This PR is ported from my fork kkimurak/docker-postgresql#9, included in releases 20250717 and later and is available for testing.