### PR TITLE
Fix permission issue on postgresql15 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ docker run --name postgresql -itd --restart always \
 
 In the above example `dbuser` with be granted access to both the `dbname1` and `dbname2` databases.
 
+If you want `DB_USER` to have ownership of database listed in `DB_NAME`, you can set `DB_USER_IS_DB_OWNER` to true.
+
 # Enabling extensions
 
 The image also packages the [postgres contrib module](http://www.postgresql.org/docs/9.4/static/contrib.html). A comma separated list of modules can be specified using the `DB_EXTENSION` parameter.

--- a/runtime/functions
+++ b/runtime/functions
@@ -342,6 +342,9 @@ create_database() {
           if [[ -n ${DB_USER} ]]; then
             echo "‣ Granting access to ${DB_USER} user..."
             psql -U ${PG_USER} -c "GRANT ALL PRIVILEGES ON DATABASE \"${database}\" to \"${DB_USER}\";" >/dev/null
+
+            echo "‣ Granting access on public schema to user '${DB_USER}'"
+            psql -U ${PG_USER} -c "GRANT ALL ON SCHEMA public TO \"${DB_USER}\";" -d "${database}" >/dev/null
           fi
         done
         ;;

--- a/runtime/functions
+++ b/runtime/functions
@@ -340,11 +340,17 @@ create_database() {
           load_extensions ${database}
 
           if [[ -n ${DB_USER} ]]; then
-            echo "‣ Granting access to ${DB_USER} user..."
-            psql -U ${PG_USER} -c "GRANT ALL PRIVILEGES ON DATABASE \"${database}\" to \"${DB_USER}\";" >/dev/null
+            if [[ "${DB_USER_IS_DB_OWNER}" == true ]]; then
+              echo "‣ Setting ${DB_USER} as an owner of database ${database}..."
+              psql -U ${PG_USER} -c "ALTER DATABASE ${database} OWNER TO ${DB_USER};" >/dev/null
+              # now DB_USER have access to table / schema where the owner is pg_database_owner (e.g. 'public' schema)
+            else
+              echo "‣ Granting access to ${DB_USER} user..."
+              psql -U ${PG_USER} -c "GRANT ALL PRIVILEGES ON DATABASE \"${database}\" to \"${DB_USER}\";" >/dev/null
 
-            echo "‣ Granting access on public schema to user '${DB_USER}'"
-            psql -U ${PG_USER} -c "GRANT ALL ON SCHEMA public TO \"${DB_USER}\";" -d "${database}" >/dev/null
+              echo "‣ Granting access on public schema to user '${DB_USER}'"
+              psql -U ${PG_USER} -c "GRANT ALL ON SCHEMA public TO \"${DB_USER}\";" -d "${database}" >/dev/null
+            fi
           fi
         done
         ;;


### PR DESCRIPTION
PostgreSQL 15 or later removed PUBLIC creation permission on the public schema. As `sameersbn/postgresql` does not have a way to set database owner, user can face permission issue. See https://www.postgresql.org/docs/15/release-15.html

This PR ports following fixes from my fork kkimurak/sameersbn-postgresql.

- Add parameter `DB_USER_IS_DB_OWNER`. If it is set to true, `DB_USER` will become an owner of database listed in `DB_NAME`. This can be direct fix of the issue.  
  
  note: This change is ported from kkimurak/docker-postgresql#10, included in releases 20250717 and later and is available for testing.
- Grant ALL privileges on the public schema to `DB_USER` if `DB_USER_IS_DB_OWNER` is not set to true.  
  This was introduced as a temporary workaround based on the error message displayed in discussion to update sameersbn/gitlab to 18.0.0 (See https://github.com/sameersbn/docker-gitlab/pull/3107#issuecomment-2888439747). 　
  
  It was later confirmed in the official documentation that the owner of the database itself was changed, and this workaround may not be correct (although it works). Therefore, I will revert this change if requested.  
  
  note: This change is ported from kkimurak/docker-postgresql#1 and kkimurak/docker-postgresql#5, included in release 20250518 or later and is available for testing.